### PR TITLE
docs: remove simulation comments from README (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,3 @@ Request a review and respond professionally.
 # Contributors
 Etim Antai (@Etim-Antai)
 Tobechukwu Emelife (@tobekami)
-
-simulation: "My change from feature/conflict-resolution-practice branch"
-simulation: "Teammate's change from main branch"


### PR DESCRIPTION
This PR removes the simulation comments left in the README file after the merge conflict exercise.  
Closes #14 
